### PR TITLE
fix: Single image pick code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Uint8List? bytesFromPicker = await ImagePickerWeb.getImageAsBytes();
 Load image as and `html.File` object :
 
 ```dart
-html.File? imageFile = await ImagePickerWeb.getMultiImagesAsFile();
+html.File? imageFile = (await ImagePickerWeb.getMultiImagesAsFile())?[0];
 ```
 
 ### Pick multiple images


### PR DESCRIPTION
README has the code for picking multiple HTML Files as images under the section demonstrating how to pick single image